### PR TITLE
Separated duplication and delivery of messages in the operational semantics

### DIFF
--- a/aneris/aneris_lang/lang.v
+++ b/aneris/aneris_lang/lang.v
@@ -982,7 +982,7 @@ Proof. destruct Ki; move => [? ?] [? ?] [? ?];
 Inductive config_step :
   state → state -> Prop :=
 | MessageDeliverStep n σ Sn Sn' sh a skt r m:
-    m ∈ (messages_to_receive_at_multi_soup a (state_ms σ)) →
+    m ∈ messages_to_receive_at_multi_soup a (state_ms σ) →
     state_sockets σ !! n = Some Sn ->
     Sn !! sh = Some (skt, r) →
     Sn' = <[sh := (skt, m :: r)]>Sn →
@@ -991,11 +991,18 @@ Inductive config_step :
                 {| state_heaps := state_heaps σ;
                    state_sockets := <[n:=Sn']>(state_sockets σ);
                    state_ports_in_use := state_ports_in_use σ;
-                   state_ms := state_ms σ; |}
+                   state_ms := state_ms σ ∖ {[+ m +]}; |}
+| MessageDuplicateStep σ m :
+    m ∈ state_ms σ →
+    config_step σ
+                {| state_heaps := state_heaps σ;
+                   state_sockets := state_sockets σ;
+                   state_ports_in_use := state_ports_in_use σ;
+                   state_ms := state_ms σ ∪ {[+ m +]}; |}
 | MessageDropStep σ m :
     m ∈ state_ms σ →
     config_step σ
-                 {| state_heaps := state_heaps σ;
+                {| state_heaps := state_heaps σ;
                    state_sockets := state_sockets σ;
                    state_ports_in_use := state_ports_in_use σ;
                    state_ms := state_ms σ ∖ {[+ m +]}; |}.

--- a/aneris/aneris_lang/state_interp/state_interp_free_ips_coh.v
+++ b/aneris/aneris_lang/state_interp/state_interp_free_ips_coh.v
@@ -197,4 +197,19 @@ Section state_interpretation.
     ddeq ip ip'; set_solver.
   Qed.
 
+  Lemma free_ips_coh_ms hps skts ports ms1 ms2 :
+    free_ips_coh {|
+      state_heaps := hps;
+      state_sockets := skts;
+      state_ports_in_use := ports;
+      state_ms := ms1;
+      |} -∗
+    free_ips_coh {|
+      state_heaps := hps;
+      state_sockets := skts;
+      state_ports_in_use := ports;
+      state_ms := ms2;
+    |}.
+  Proof. done. Qed.
+
 End state_interpretation.

--- a/aneris/aneris_lang/state_interp/state_interp_messages_history.v
+++ b/aneris/aneris_lang/state_interp/state_interp_messages_history.v
@@ -185,15 +185,35 @@ Lemma message_history_evolution_deliver_message ip Sn sh skt r m S M rt :
   S !! ip = Some Sn →
   Sn !! sh = Some (skt, r) →
   rt = message_history_evolution
-         M M S (<[ip:=<[sh:=(skt, m::r)]> Sn]> S) rt.
+         M (M ∖ {[+ m +]}) S (<[ip:=<[sh:=(skt, m::r)]> Sn]> S) rt.
 Proof.
   intros ??.
   rewrite /message_history_evolution.
   destruct rt as (R, T).
-  simplify_eq /=.
-  rewrite !gmultiset_difference_diag gset_of_gmultiset_empty !left_id_L. f_equal.
+  assert (M ∖ {[+ m +]} ∖ M = ∅) as -> by multiset_solver.
+  f_equal; [|by set_solver].
   rewrite gmultiset_empty_difference; first set_solver.
   by eapply buffers_subseteq.
+Qed.
+
+(* TODO: Figure out why difference_union_dist_l_L is not sufficient. *)
+Lemma gmultiset_difference_union_distr_l_L `{Countable A}
+      (X Y Z : gmultiset A) :
+  (X ∪ Y) ∖ Z = X ∖ Z ∪ Y ∖ Z.
+Proof. multiset_solver. Qed.
+
+Lemma message_history_evolution_duplicate_message S M M' rt :
+  M' ⊆ M → rt = message_history_evolution M (M ∪ M') S S rt.
+Proof.
+  intros ?.
+  rewrite /message_history_evolution.
+  destruct rt as (R, T).
+  rewrite !gmultiset_difference_diag.
+  assert (dom (D := message_soup) (∅ : gmultiset _) = ∅) as Hempty by multiset_solver.
+  rewrite Hempty. f_equal; [multiset_solver|].
+  rewrite gmultiset_difference_union_distr_l_L gmultiset_difference_diag
+          gmultiset_empty_difference; [|multiset_solver].
+  rewrite left_id. set_solver.
 Qed.
 
 Lemma message_history_evolution_drop_message S M M' rt :

--- a/aneris/aneris_lang/state_interp/state_interp_messages_history_coh.v
+++ b/aneris/aneris_lang/state_interp/state_interp_messages_history_coh.v
@@ -276,9 +276,20 @@ Section state_interpretation.
     - by rewrite lookup_insert_ne in HSn1; eauto.
   Qed.
 
-  Lemma messages_history_drop_message σ mhγ m :
-    messages_history_coh (state_ms σ) (state_sockets σ) mhγ →
-    messages_history_coh (state_ms σ ∖ {[+ m +]}) (state_sockets σ) mhγ.
+  Lemma messages_history_coh_duplicate_message M S mhm m :
+    m ∈ M →
+    messages_history_coh M S mhm → messages_history_coh (M ∪ {[+ m +]}) S mhm.
+  Proof.
+    intros Hin (HMcoh&Hrbuf&Hacoh&Hrsfcoh).
+    split; [|done].
+    intros m' [Hin'|Hin']%gmultiset_elem_of_union; [by eauto|].
+    apply gmultiset_elem_of_singleton in Hin' as ->.
+    by eauto.
+  Qed.
+
+  Lemma messages_history_coh_drop_message σ S mhγ m :
+    messages_history_coh (state_ms σ) S mhγ →
+    messages_history_coh (state_ms σ ∖ {[+ m +]}) S mhγ.
   Proof.
     unfold messages_history_coh. intros (Hmsh & Hrb & Hmac & Hmr).
     split_and!; [|done..].


### PR DESCRIPTION
Following recent discussion it sounds like it makes sense to separate the duplication and delivery of messages in the
operational semantics.

One benefit of this is that it allows tracking of the two as separate events, which for instance lets us talk about the
behaviour of duplication in the network, as a separate entity from delivery in the eventual fairness traces of Aneris.